### PR TITLE
[FEAT] CourseSection, CourseContent 도메인 모델 구현

### DIFF
--- a/src/main/java/com/lxp/course/model/Course.java
+++ b/src/main/java/com/lxp/course/model/Course.java
@@ -190,4 +190,8 @@ public class Course {
         this.updatedAt = LocalDateTime.now();
     }
 
+    // getters
+    public Long getId() {
+        return id;
+    }
 }

--- a/src/main/java/com/lxp/course/model/Course.java
+++ b/src/main/java/com/lxp/course/model/Course.java
@@ -152,6 +152,7 @@ public class Course {
         if (this.status != DRAFT) {
             throw new IllegalStateException("DRAFT 상태인 강좌에만 섹션을 추가할 수 있습니다.");
         }
+        
         this.sections.add(section);
         this.updatedAt = LocalDateTime.now();
     }

--- a/src/main/java/com/lxp/course/model/CourseContent.java
+++ b/src/main/java/com/lxp/course/model/CourseContent.java
@@ -93,5 +93,8 @@ public class CourseContent {
     public boolean isNormal() {
         return this.status == NORMAL;
     }
-    
+
+    public CourseSection getSection() {
+        return section;
+    }
 }

--- a/src/main/java/com/lxp/course/model/CourseContent.java
+++ b/src/main/java/com/lxp/course/model/CourseContent.java
@@ -2,13 +2,94 @@ package com.lxp.course.model;
 
 import static com.lxp.course.model.ContentStatus.NORMAL;
 
+import java.time.LocalDateTime;
+
 public class CourseContent {
 
     private Long id;
     private String title;
-    private ContentStatus status;
     private ContentType type;
+    private ContentStatus status;
+    private CourseSection section;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
 
+    private CourseContent() {
+    }
+
+    private CourseContent(String title, ContentType type, ContentStatus status,
+            CourseSection section) {
+        validateTitle(title);
+        validateType(type);
+        validateStatus(status);
+        validateSection(section);
+
+        this.title = title;
+        this.type = type;
+        this.status = status;
+        this.section = section;
+        this.createdAt = LocalDateTime.now();
+        this.updatedAt = createdAt;
+    }
+
+    /**
+     * 새 콘텐츠를 생성한다.
+     *
+     * <p> 초기 상태는 NORMAL 또는 HIDDEN으로 설정 가능하다.
+     */
+    public static CourseContent create(String title, ContentType type, ContentStatus status,
+            CourseSection section) {
+        return new CourseContent(title, type, status, section);
+    }
+
+    /**
+     * DB 조회 결과로부터 CourseContent 객체를 복원한다.
+     *
+     * <p> CourseContentRepository에서만 호출되어야 한다. (package-private)
+     */
+    static CourseContent reconstruct(Long id, String title, ContentType type, ContentStatus status,
+            CourseSection section, LocalDateTime createdAt, LocalDateTime updatedAt) {
+        CourseContent content = new CourseContent();
+        content.id = id;
+        content.title = title;
+        content.type = type;
+        content.status = status;
+        content.section = section;
+        content.createdAt = createdAt;
+        content.updatedAt = updatedAt;
+        return content;
+    }
+
+    private void validateTitle(String title) {
+        if (title == null || title.isBlank()) {
+            throw new IllegalArgumentException("콘텐츠 제목은 필수입니다.");
+        }
+        if (title.length() > 50) {
+            throw new IllegalArgumentException("콘텐츠 제목은 50자 이하여야 합니다.");
+        }
+    }
+
+    private void validateType(ContentType type) {
+        if (type == null) {
+            throw new IllegalArgumentException("콘텐츠 타입은 필수입니다.");
+        }
+    }
+
+    private void validateStatus(ContentStatus status) {
+        if (status == null) {
+            throw new IllegalArgumentException("콘텐츠 상태는 필수입니다.");
+        }
+    }
+
+    private void validateSection(CourseSection section) {
+        if (section == null) {
+            throw new IllegalArgumentException("섹션 정보는 필수입니다.");
+        }
+    }
+
+    /**
+     * 학습자에게 노출 가능한 콘텐츠인지 확인한다.
+     */
     public boolean isNormal() {
         return this.status == NORMAL;
     }

--- a/src/main/java/com/lxp/course/model/CourseSection.java
+++ b/src/main/java/com/lxp/course/model/CourseSection.java
@@ -80,9 +80,17 @@ public class CourseSection {
         if (content == null) {
             throw new IllegalArgumentException("콘텐츠 정보는 필수입니다.");
         }
-        
+
+        if (!isOwnerOf(content)) {
+            throw new IllegalArgumentException("해당 섹션에 속한 콘텐츠만 추가할 수 있습니다.");
+        }
+
         this.contents.add(content);
         this.updatedAt = LocalDateTime.now();
+    }
+
+    private boolean isOwnerOf(CourseContent content) {
+        return content != null && content.getSection() == this;
     }
 
     public Long getId() {

--- a/src/main/java/com/lxp/course/model/CourseSection.java
+++ b/src/main/java/com/lxp/course/model/CourseSection.java
@@ -7,16 +7,94 @@ import java.util.List;
 
 public class CourseSection {
 
+
     private Long id;
     private String title;
     private Course course;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 
-    private List<CourseContent> contents = new ArrayList<>();
+    private final List<CourseContent> contents = new ArrayList<>();
+
+    private CourseSection() {
+    }
+
+    private CourseSection(String title, Course course) {
+        validateTitle(title);
+        validateCourse(course);
+
+        this.title = title;
+        this.course = course;
+        this.createdAt = LocalDateTime.now();
+        this.updatedAt = createdAt;
+    }
+
+    /**
+     * 새 섹션을 생성한다.
+     *
+     * <p> 참조되는 강좌의 상태가 DRAFT여야 한다.
+     */
+    public static CourseSection create(String title, Course course) {
+        return new CourseSection(title, course);
+    }
+
+    /**
+     * DB 조회 결과로부터 CourseSection 객체를 복원한다.
+     *
+     * <p> CourseSectionRepository에서만 호출되어야 한다. (package-private)
+     */
+    static CourseSection reconstruct(Long id, String title, Course course,
+            LocalDateTime createdAt, LocalDateTime updatedAt) {
+        CourseSection section = new CourseSection();
+        section.id = id;
+        section.title = title;
+        section.course = course;
+        section.createdAt = createdAt;
+        section.updatedAt = updatedAt;
+        return section;
+    }
+
+    private void validateTitle(String title) {
+        if (title == null || title.isBlank()) {
+            throw new IllegalArgumentException("섹션 제목은 필수입니다.");
+        }
+
+        if (title.length() > 50) {
+            throw new IllegalArgumentException("섹션 제목은 50자 이하여야 합니다.");
+        }
+    }
+
+    private void validateCourse(Course course) {
+        if (course == null) {
+            throw new IllegalArgumentException("강좌 정보는 필수입니다.");
+        }
+        if (!course.isDraft()) {
+            throw new IllegalStateException("DRAFT 상태인 강좌에만 섹션을 추가할 수 있습니다.");
+        }
+    }
+
+    /**
+     * 콘텐츠를 추가한다.
+     */
+    public void addContent(CourseContent content) {
+        if (content == null) {
+            throw new IllegalArgumentException("콘텐츠 정보는 필수입니다.");
+        }
+        
+        this.contents.add(content);
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public Long getId() {
+        return id;
+    }
 
     public String getTitle() {
         return title;
+    }
+
+    public Course getCourse() {
+        return course;
     }
 
     public List<CourseContent> getContents() {


### PR DESCRIPTION
### 📝 구현 내용

강좌 섹션(CourseSection), 강좌 컨텐츠(CourseContent) 도메인 모델을 구현했습니다.

- 객체 생성 메서드 : `create()` , `reconstruct()`
도메인 객체 생성은 create() (신규 생성)와 reconstruct() (DB 복원) 두 가지 정적 팩토리 메서드로 분리했습니다. 신규 생성 시에는 도메인의 불변식이 보장되도록 검증을 수행하며, reconstruct()는 이미 저장된 데이터를 복원하는 용도이므로 도메인 검증을 수행하지 않습니다.

- 도메인 행위 메서드
CourseSection에는 콘텐츠를 추가하는 메서드, CourseContent에는 해당 콘텐츠가 normal 상태인지 판별하는 메서드를 구현했습니다.

### 📂 주요 변경 파일
- CourseSection.java
- CourseContent.java

## 🤔 고민했던 부분
어려움: 다른 엔티티를 참조해야할 때 객체 타입으로 참조할지, 해당 객체의 id만 참조할지를 고민했습니다.
선택: 객체 타입으로 참조했습니다.
결과: 객체 간 결합도가 높지만, 객체의 상태를 즉시 확인하고 비즈니스 규칙을 강제할 수 있습니다.

### 📌 참고사항
Course 모델과 구조가 거의 흡사합니다. 리뷰 시 참고 부탁드려요!