### PR TITLE
[FEAT] 강좌 조회 구현

### DIFF
--- a/src/main/java/com/lxp/Application.java
+++ b/src/main/java/com/lxp/Application.java
@@ -4,6 +4,7 @@ import com.lxp.course.controller.CourseController;
 import com.lxp.course.model.Course;
 import com.lxp.course.model.CourseContent;
 import com.lxp.course.model.CourseSection;
+import com.lxp.course.model.dto.CourseDetailResponse;
 import com.lxp.course.model.enums.ContentStatus;
 import com.lxp.course.model.enums.ContentType;
 import com.lxp.course.model.enums.CourseLevel;
@@ -30,6 +31,7 @@ public class Application {
             System.out.println("2. 강좌 섹션 등록");
             System.out.println("3. 강좌 컨텐츠 등록");
             System.out.println("4. 강좌 전체 조회");
+            System.out.println("5. 강좌 상세 조회");
             System.out.println("0. 종료");
             System.out.print("선택: ");
 
@@ -40,6 +42,7 @@ public class Application {
                 case "2" -> handleCreateSection();
                 case "3" -> handleCreateContent();
                 case "4" -> handleGetAllCourses();
+                case "5" -> handleGetCourseDetail();
                 case "0" -> {
                     System.out.println("종료합니다.");
                     scanner.close();
@@ -134,6 +137,57 @@ public class Application {
                 System.out.println("강사 ID     : " + course.getInstructorId());
                 System.out.println("상태        : " + course.getStatus());
                 System.out.println("난이도      : " + course.getLevel());
+            }
+
+        } catch (NumberFormatException e) {
+            System.out.println("[오류] ID는 숫자로 입력해주세요.");
+        } catch (IllegalArgumentException e) {
+            System.out.println("[오류] " + e.getMessage());
+        }
+    }
+
+    private void handleGetCourseDetail() {
+        System.out.println("\n=== 강좌 단일 조회 ===");
+
+        try {
+            System.out.print("강좌 ID: ");
+            Long courseId = Long.parseLong(scanner.nextLine().trim());
+
+            CourseDetailResponse courseDetail = courseController.getCourseDetail(courseId);
+            Course course = courseDetail.course();
+            List<CourseSection> sections = courseDetail.sections();
+
+            System.out.println();
+            System.out.println("■ 강좌 정보");
+            System.out.println("  ID      : " + course.getId());
+            System.out.println("  제목    : " + course.getTitle());
+            System.out.println("  설명    : " + course.getDescription());
+            System.out.println("  강사 ID : " + course.getInstructorId());
+            System.out.println("  상태    : " + course.getStatus());
+            System.out.println("  난이도  : " + course.getLevel());
+            System.out.println("  발행일  : " + (course.getPublishedAt() != null
+                    ? course.getPublishedAt() : "미발행"));
+
+            if (sections.isEmpty()) {
+                System.out.println("\n  등록된 섹션이 없습니다.");
+                return;
+            }
+
+            for (CourseSection section : sections) {
+                System.out.println("\n  ▶ 섹션 [ID " + section.getId() + "] " + section.getTitle());
+
+                List<CourseContent> contents = section.getContents();
+                if (contents.isEmpty()) {
+                    System.out.println("    등록된 콘텐츠가 없습니다.");
+                } else {
+                    for (CourseContent content : contents) {
+                        System.out.printf("    - [ID %d] %s  (%s / %s)%n",
+                                content.getId(),
+                                content.getTitle(),
+                                content.getType(),
+                                content.getStatus());
+                    }
+                }
             }
 
         } catch (NumberFormatException e) {

--- a/src/main/java/com/lxp/Application.java
+++ b/src/main/java/com/lxp/Application.java
@@ -9,6 +9,7 @@ import com.lxp.course.model.enums.ContentType;
 import com.lxp.course.model.enums.CourseLevel;
 import com.lxp.global.config.AppConfig;
 import java.sql.SQLException;
+import java.util.List;
 import java.util.Scanner;
 
 public class Application {
@@ -28,6 +29,7 @@ public class Application {
             System.out.println("1. 강좌 등록");
             System.out.println("2. 강좌 섹션 등록");
             System.out.println("3. 강좌 컨텐츠 등록");
+            System.out.println("4. 강좌 전체 조회");
             System.out.println("0. 종료");
             System.out.print("선택: ");
 
@@ -37,6 +39,7 @@ public class Application {
                 case "1" -> handleCreateCourse();
                 case "2" -> handleCreateSection();
                 case "3" -> handleCreateContent();
+                case "4" -> handleGetAllCourses();
                 case "0" -> {
                     System.out.println("종료합니다.");
                     scanner.close();
@@ -113,6 +116,29 @@ public class Application {
         } catch (NumberFormatException e) {
             System.out.println("[오류] ID는 숫자로 입력해주세요.");
         } catch (IllegalArgumentException | IllegalStateException e) {
+            System.out.println("[오류] " + e.getMessage());
+        }
+    }
+
+    public void handleGetAllCourses() {
+        System.out.println("\n=== 강좌 전체 조회 ===");
+
+        try {
+            List<Course> allCourses = courseController.getAllCourses();
+
+            for (Course course : allCourses) {
+                System.out.println();
+                System.out.println("ID          : " + course.getId());
+                System.out.println("제목        : " + course.getTitle());
+                System.out.println("설명        : " + course.getDescription());
+                System.out.println("강사 ID     : " + course.getInstructorId());
+                System.out.println("상태        : " + course.getStatus());
+                System.out.println("난이도      : " + course.getLevel());
+            }
+
+        } catch (NumberFormatException e) {
+            System.out.println("[오류] ID는 숫자로 입력해주세요.");
+        } catch (IllegalArgumentException e) {
             System.out.println("[오류] " + e.getMessage());
         }
     }

--- a/src/main/java/com/lxp/course/controller/CourseController.java
+++ b/src/main/java/com/lxp/course/controller/CourseController.java
@@ -45,12 +45,12 @@ public class CourseController {
     }
 
     public List<Course> getAllCourses() {
-        return courseService.getCoursesByStatus();
+        return courseService.getAllCourses();
     }
 
     public CourseDetailResponse getCourseDetail(Long courseId) {
         Course course = courseService.getCourseWithDetail(courseId);
         return CourseDetailResponse.from(course);
     }
-    
+
 }

--- a/src/main/java/com/lxp/course/controller/CourseController.java
+++ b/src/main/java/com/lxp/course/controller/CourseController.java
@@ -7,6 +7,7 @@ import com.lxp.course.model.enums.ContentStatus;
 import com.lxp.course.model.enums.ContentType;
 import com.lxp.course.model.enums.CourseLevel;
 import com.lxp.course.service.CourseService;
+import java.util.List;
 import java.util.Scanner;
 
 public class CourseController {
@@ -40,5 +41,9 @@ public class CourseController {
     public CourseContent createContent(Long sectionId, String title, ContentType type,
             ContentStatus status) {
         return courseService.createContent(sectionId, title, type, status);
+    }
+
+    public List<Course> getAllCourses() {
+        return courseService.getCoursesByStatus();
     }
 }

--- a/src/main/java/com/lxp/course/controller/CourseController.java
+++ b/src/main/java/com/lxp/course/controller/CourseController.java
@@ -3,6 +3,7 @@ package com.lxp.course.controller;
 import com.lxp.course.model.Course;
 import com.lxp.course.model.CourseContent;
 import com.lxp.course.model.CourseSection;
+import com.lxp.course.model.dto.CourseDetailResponse;
 import com.lxp.course.model.enums.ContentStatus;
 import com.lxp.course.model.enums.ContentType;
 import com.lxp.course.model.enums.CourseLevel;
@@ -46,4 +47,10 @@ public class CourseController {
     public List<Course> getAllCourses() {
         return courseService.getCoursesByStatus();
     }
+
+    public CourseDetailResponse getCourseDetail(Long courseId) {
+        Course course = courseService.getCourseWithDetail(courseId);
+        return CourseDetailResponse.from(course);
+    }
+    
 }

--- a/src/main/java/com/lxp/course/model/Course.java
+++ b/src/main/java/com/lxp/course/model/Course.java
@@ -76,6 +76,15 @@ public class Course {
         return course;
     }
 
+    /**
+     * DB 조회 결과 복원 시 섹션을 추가한다.
+     *
+     * <p> 이미 저장된 데이터를 복원하는 것이므로 도메인 검증을 수행하지 않는다.
+     */
+    public void addSectionForReconstruct(CourseSection section) {
+        this.sections.add(section);
+    }
+
     private void validateTitle(String title) {
         if (title == null || title.isBlank()) {
             throw new IllegalArgumentException("강좌명은 필수입니다.");

--- a/src/main/java/com/lxp/course/model/CourseSection.java
+++ b/src/main/java/com/lxp/course/model/CourseSection.java
@@ -51,6 +51,10 @@ public class CourseSection {
         return section;
     }
 
+    public void addContentForReconstruct(CourseContent content) {
+        this.contents.add(content);
+    }
+
     private void validateTitle(String title) {
         if (title == null || title.isBlank()) {
             throw new IllegalArgumentException("섹션 제목은 필수입니다.");

--- a/src/main/java/com/lxp/course/model/dto/CourseDetailResponse.java
+++ b/src/main/java/com/lxp/course/model/dto/CourseDetailResponse.java
@@ -1,4 +1,16 @@
 package com.lxp.course.model.dto;
 
-public record CourseDetailResponse() {
+import com.lxp.course.model.Course;
+import com.lxp.course.model.CourseSection;
+import java.util.List;
+
+public record CourseDetailResponse(
+        Course course,
+        List<CourseSection> sections
+) {
+
+    public static CourseDetailResponse from(Course course) {
+        return new CourseDetailResponse(course, course.getSections());
+    }
+
 }

--- a/src/main/java/com/lxp/course/model/dto/CourseDetailResponse.java
+++ b/src/main/java/com/lxp/course/model/dto/CourseDetailResponse.java
@@ -1,0 +1,4 @@
+package com.lxp.course.model.dto;
+
+public record CourseDetailResponse() {
+}

--- a/src/main/java/com/lxp/course/repository/CourseRepository.java
+++ b/src/main/java/com/lxp/course/repository/CourseRepository.java
@@ -1,6 +1,7 @@
 package com.lxp.course.repository;
 
 import com.lxp.course.model.Course;
+import java.util.List;
 import java.util.Optional;
 
 public interface CourseRepository {
@@ -8,5 +9,7 @@ public interface CourseRepository {
     Course save(Course course);
 
     Optional<Course> findById(Long id);
-    
+
+    List<Course> findAll();
+
 }

--- a/src/main/java/com/lxp/course/repository/CourseRepository.java
+++ b/src/main/java/com/lxp/course/repository/CourseRepository.java
@@ -11,5 +11,6 @@ public interface CourseRepository {
     Optional<Course> findById(Long id);
 
     List<Course> findAll();
-
+    
+    Optional<Course> findWithSectionsAndContentsById(Long id);
 }

--- a/src/main/java/com/lxp/course/repository/JdbcCourseRepository.java
+++ b/src/main/java/com/lxp/course/repository/JdbcCourseRepository.java
@@ -9,6 +9,8 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 import javax.sql.DataSource;
 
@@ -100,6 +102,42 @@ public class JdbcCourseRepository implements CourseRepository {
 
         } catch (SQLException e) {
             throw new RuntimeException("강좌 조회 중 오류가 발생했습니다.", e);
+        }
+    }
+
+    @Override
+    public List<Course> findAll() {
+        String sql = """
+                SELECT id, title, description, instructor_id, status, level,
+                       published_at, created_at, updated_at
+                FROM courses
+                ORDER BY id
+                """;
+
+        try (Connection conn = dataSource.getConnection();
+                PreparedStatement pstmt = conn.prepareStatement(sql)) {
+
+            try (ResultSet rs = pstmt.executeQuery()) {
+                List<Course> courses = new ArrayList<>();
+                while (rs.next()) {
+                    courses.add(Course.reconstruct(
+                            rs.getLong("id"),
+                            rs.getString("title"),
+                            rs.getString("description"),
+                            rs.getLong("instructor_id"),
+                            CourseStatus.valueOf(rs.getString("status")),
+                            CourseLevel.valueOf(rs.getString("level")),
+                            rs.getTimestamp("published_at") != null
+                                    ? rs.getTimestamp("published_at").toLocalDateTime() : null,
+                            rs.getTimestamp("created_at").toLocalDateTime(),
+                            rs.getTimestamp("updated_at").toLocalDateTime()
+                    ));
+                }
+                return courses;
+            }
+
+        } catch (SQLException e) {
+            throw new RuntimeException("강좌 목록 조회 중 오류가 발생했습니다.", e);
         }
     }
 }

--- a/src/main/java/com/lxp/course/repository/JdbcCourseRepository.java
+++ b/src/main/java/com/lxp/course/repository/JdbcCourseRepository.java
@@ -1,6 +1,10 @@
 package com.lxp.course.repository;
 
 import com.lxp.course.model.Course;
+import com.lxp.course.model.CourseContent;
+import com.lxp.course.model.CourseSection;
+import com.lxp.course.model.enums.ContentStatus;
+import com.lxp.course.model.enums.ContentType;
 import com.lxp.course.model.enums.CourseLevel;
 import com.lxp.course.model.enums.CourseStatus;
 import java.sql.Connection;
@@ -9,8 +13,11 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.sql.Timestamp;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import javax.sql.DataSource;
 
@@ -138,6 +145,124 @@ public class JdbcCourseRepository implements CourseRepository {
 
         } catch (SQLException e) {
             throw new RuntimeException("강좌 목록 조회 중 오류가 발생했습니다.", e);
+        }
+    }
+
+    @Override
+    public Optional<Course> findWithSectionsAndContentsById(Long id) {
+        // SQL 정의: 강좌-섹션-콘텐츠를 한 번에 조회 (1:N:M 관계)
+        // - LEFT JOIN: 섹션이나 콘텐츠가 없는 강좌라도 정보를 가져오기 위함
+        // - ORDER BY: 동일한 섹션끼리, 동일한 콘텐츠끼리 데이터가 모이도록 정렬함
+        String sql = """
+                SELECT
+                    c.id AS course_id, c.title AS course_title, c.description,
+                    c.instructor_id, c.status, c.level, c.published_at,
+                    c.created_at AS course_created_at, c.updated_at AS course_updated_at,
+                    s.id AS section_id, s.title AS section_title,
+                    s.created_at AS section_created_at, s.updated_at AS section_updated_at,
+                    ct.id AS content_id, ct.title AS content_title,
+                    ct.content_type, ct.status AS content_status,
+                    ct.created_at AS content_created_at, ct.updated_at AS content_updated_at
+                FROM courses c
+                LEFT JOIN course_sections s ON c.id = s.course_id
+                LEFT JOIN contents ct ON s.id = ct.section_id
+                WHERE c.id = ?
+                ORDER BY s.id, ct.id
+                """;
+
+        try (Connection conn = dataSource.getConnection();
+                PreparedStatement pstmt = conn.prepareStatement(sql)) {
+
+            pstmt.setLong(1, id);
+
+            try (ResultSet rs = pstmt.executeQuery()) {
+                Course course = null;
+                // 섹션 중복 방지 및 순서 유지를 위해 LinkedHashMap 사용 (Key: SectionID, Value: Section 객체)
+                Map<Long, CourseSection> sectionMap = new LinkedHashMap<>();
+
+                while (rs.next()) {
+                    // 루트 객체(Course) 초기화
+                    // 결과셋의 모든 행에는 동일한 강좌 정보가 포함되어 있으므로, 첫 행에서 딱 한 번만 생성함
+                    if (course == null) {
+                        course = Course.reconstruct(
+                                rs.getLong("course_id"),
+                                rs.getString("course_title"),
+                                rs.getString("description"),
+                                rs.getLong("instructor_id"),
+                                CourseStatus.valueOf(rs.getString("status")),
+                                CourseLevel.valueOf(rs.getString("level")),
+                                rs.getTimestamp("published_at") != null
+                                        ? rs.getTimestamp("published_at").toLocalDateTime() : null,
+                                rs.getTimestamp("course_created_at").toLocalDateTime(),
+                                rs.getTimestamp("course_updated_at").toLocalDateTime()
+                        );
+                    }
+
+                    // 섹션(Section) 데이터 처리
+                    long sectionId = rs.getLong("section_id");
+                    // LEFT JOIN 결과로 섹션 정보가 없는 경우(null) 다음 행으로 넘어감
+                    if (rs.wasNull()) {
+                        continue;
+                    }
+
+                    // 이미 Map에 등록된 섹션인지 확인 (하나의 섹션에 여러 콘텐츠가 있으면 행이 여러 개 발생하므로 중복 제거 필요)
+                    CourseSection section = sectionMap.get(sectionId);
+                    if (section == null) {
+                        section = CourseSection.reconstruct(
+                                sectionId,
+                                rs.getString("section_title"),
+                                course, // 섹션이 부모인 Course를 참조하도록 설정
+                                getLocalDateTime(rs, "section_created_at"),
+                                getLocalDateTime(rs, "section_updated_at")
+                        );
+                        sectionMap.put(sectionId, section);
+                    }
+
+                    // 콘텐츠(Content) 데이터 처리
+                    long contentId = rs.getLong("content_id");
+                    // 해당 섹션에 콘텐츠가 없는 경우(null), 콘텐츠 생성 단계를 건너뜀
+                    if (rs.wasNull()) {
+                        continue;
+                    }
+
+                    // 콘텐츠 객체 생성 및 현재 섹션에 추가
+                    CourseContent content = CourseContent.reconstruct(
+                            contentId,
+                            rs.getString("content_title"),
+                            ContentType.valueOf(rs.getString("content_type")),
+                            ContentStatus.valueOf(rs.getString("content_status")),
+                            section, // 콘텐츠가 부모인 Section을 참조하도록 설정
+                            getLocalDateTime(rs, "content_created_at"),
+                            getLocalDateTime(rs, "content_updated_at")
+                    );
+                    // 섹션 내부 리스트에 콘텐츠 추가 (Reconstruct 전용 메서드 사용)
+                    section.addContentForReconstruct(content);
+                }
+
+                // 최종 결과 반환 처리
+                // 조회된 강좌 자체가 없으면 빈 Optional 반환
+                if (course == null) {
+                    return Optional.empty();
+                }
+
+                // Map에 모아둔 모든 섹션들을 강좌 객체에 최종적으로 연결
+                sectionMap.values().forEach(course::addSectionForReconstruct);
+
+                return Optional.of(course);
+            }
+
+        } catch (SQLException e) {
+            // 예외 발생 시 구체적인 메시지를 담아 RuntimeException으로 전환하여 던짐
+            throw new RuntimeException("강좌 상세 조회 중 오류가 발생했습니다.", e);
+        }
+    }
+
+    private LocalDateTime getLocalDateTime(ResultSet rs, String column) {
+        try {
+            Timestamp ts = rs.getTimestamp(column);
+            return ts != null ? ts.toLocalDateTime() : null;
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
         }
     }
 }

--- a/src/main/java/com/lxp/course/service/CourseService.java
+++ b/src/main/java/com/lxp/course/service/CourseService.java
@@ -85,7 +85,7 @@ public class CourseService {
         return contentRepository.save(content);
     }
 
-    public List<Course> getCoursesByStatus() {
+    public List<Course> getAllCourses() {
         return courseRepository.findAll();
     }
 

--- a/src/main/java/com/lxp/course/service/CourseService.java
+++ b/src/main/java/com/lxp/course/service/CourseService.java
@@ -11,6 +11,7 @@ import com.lxp.course.repository.CourseRepository;
 import com.lxp.course.repository.CourseSectionRepository;
 import com.lxp.user.model.User;
 import com.lxp.user.repository.UserRepository;
+import java.util.List;
 
 public class CourseService {
 
@@ -82,5 +83,9 @@ public class CourseService {
         section.addContent(content);
 
         return contentRepository.save(content);
+    }
+
+    public List<Course> getCoursesByStatus() {
+        return courseRepository.findAll();
     }
 }

--- a/src/main/java/com/lxp/course/service/CourseService.java
+++ b/src/main/java/com/lxp/course/service/CourseService.java
@@ -88,4 +88,9 @@ public class CourseService {
     public List<Course> getCoursesByStatus() {
         return courseRepository.findAll();
     }
+
+    public Course getCourseWithDetail(Long courseId) {
+        return courseRepository.findWithSectionsAndContentsById(courseId).orElseThrow(
+                () -> new IllegalArgumentException("존재하지 않는 강좌입니다. id=" + courseId));
+    }
 }


### PR DESCRIPTION
### 📝 구현 내용
강좌 전체 조회와 상세 조회 기능을 구현했습니다.
- 강좌 전체 조회: 전체 강좌의 정보(ID, 제목, 설명, 강사 ID, 상태, 난이도)를 목록으로 조회
- 강좌 상세 조회: 특정 강좌의 하위 섹션 및 콘텐츠를 포함한 상세 정보 조회

### 📂 주요 변경 파일
- JdbcCourseRepository.java
- CourseService.java
- CourseController.java
- Application.java

## 🤔 고민했던 부분
어려움: `강좌-섹션-콘텐츠` 정보를 한번의 쿼리로 조회하여 계층적 구조로 매핑하는 방법에 대해 고민했습니다.
선택: LinkedHashMap으로 중복된 섹션 정보를 관리하고, 마지막에 루트 객체(Course)에 추가해서 복원하는 방식으로 계층적 관계를 구현했습니다.

### 📌 참고사항
1. 강좌 전체 조회 시 실행 결과
<img width="550" height="645" alt="image" src="https://github.com/user-attachments/assets/f655fa52-dd4f-44e1-bb33-0fe562a82bb2" />
 
2. 강좌 상세 조회 시 실행 결과 
<img width="531" height="522" alt="image" src="https://github.com/user-attachments/assets/0106cdec-a09c-4a3a-a77b-292ea61645aa" />
