### PR TITLE
[FEAT] 강좌 발행 구현

### DIFF
--- a/src/main/java/com/lxp/Application.java
+++ b/src/main/java/com/lxp/Application.java
@@ -32,6 +32,7 @@ public class Application {
             System.out.println("3. 강좌 컨텐츠 등록");
             System.out.println("4. 강좌 전체 조회");
             System.out.println("5. 강좌 상세 조회");
+            System.out.println("6. 강좌 발행");
             System.out.println("0. 종료");
             System.out.print("선택: ");
 
@@ -43,6 +44,7 @@ public class Application {
                 case "3" -> handleCreateContent();
                 case "4" -> handleGetAllCourses();
                 case "5" -> handleGetCourseDetail();
+                case "6" -> handlePublishCourse();
                 case "0" -> {
                     System.out.println("종료합니다.");
                     scanner.close();
@@ -193,6 +195,22 @@ public class Application {
         } catch (NumberFormatException e) {
             System.out.println("[오류] ID는 숫자로 입력해주세요.");
         } catch (IllegalArgumentException e) {
+            System.out.println("[오류] " + e.getMessage());
+        }
+    }
+
+    private void handlePublishCourse() {
+        try {
+            System.out.print("발행하려는 강좌 ID: ");
+            Long courseId = Long.parseLong(scanner.nextLine().trim());
+
+            Course publishCourse = courseController.publishCourse(courseId);
+
+            System.out.printf("%n강좌가 발행되었습니다. [ID: %d] %s%n",
+                    publishCourse.getId(), publishCourse.getTitle());
+        } catch (NumberFormatException e) {
+            System.out.println("[오류] ID는 숫자로 입력해주세요.");
+        } catch (IllegalArgumentException | IllegalStateException e) {
             System.out.println("[오류] " + e.getMessage());
         }
     }

--- a/src/main/java/com/lxp/course/controller/CourseController.java
+++ b/src/main/java/com/lxp/course/controller/CourseController.java
@@ -44,15 +44,24 @@ public class CourseController {
         return courseService.createContent(sectionId, title, type, status);
     }
 
+    /**
+     * 모든 강좌를 조회한다.
+     */
     public List<Course> getAllCourses() {
         return courseService.getAllCourses();
     }
 
+    /**
+     * 강좌의 상세 정보를 조회한다. 강좌에 속한 섹션과 컨텐츠를 모두 반환한다.
+     */
     public CourseDetailResponse getCourseDetail(Long courseId) {
         Course course = courseService.getCourseWithDetail(courseId);
         return CourseDetailResponse.from(course);
     }
 
+    /**
+     * 강좌를 발행한다.
+     */
     public Course publishCourse(Long courseId) {
         return courseService.publishCourse(courseId);
     }

--- a/src/main/java/com/lxp/course/controller/CourseController.java
+++ b/src/main/java/com/lxp/course/controller/CourseController.java
@@ -53,4 +53,7 @@ public class CourseController {
         return CourseDetailResponse.from(course);
     }
 
+    public Course publishCourse(Long courseId) {
+        return courseService.publishCourse(courseId);
+    }
 }

--- a/src/main/java/com/lxp/course/repository/CourseRepository.java
+++ b/src/main/java/com/lxp/course/repository/CourseRepository.java
@@ -11,6 +11,9 @@ public interface CourseRepository {
     Optional<Course> findById(Long id);
 
     List<Course> findAll();
-    
+
     Optional<Course> findWithSectionsAndContentsById(Long id);
+
+    void update(Course course);
+
 }

--- a/src/main/java/com/lxp/course/repository/JdbcCourseRepository.java
+++ b/src/main/java/com/lxp/course/repository/JdbcCourseRepository.java
@@ -265,4 +265,28 @@ public class JdbcCourseRepository implements CourseRepository {
             throw new RuntimeException(e);
         }
     }
+
+    @Override
+    public void update(Course course) {
+        String sql = """
+                UPDATE Courses
+                SET status = ?, published_at = ?, updated_at = ?
+                WHERE id = ?
+                """;
+
+        try (Connection conn = dataSource.getConnection();
+                PreparedStatement pstmt = conn.prepareStatement(sql)) {
+
+            pstmt.setString(1, course.getStatus().name());
+            pstmt.setTimestamp(2, course.getPublishedAt() != null
+                    ? Timestamp.valueOf(course.getPublishedAt()) : null);
+            pstmt.setTimestamp(3, Timestamp.valueOf(course.getUpdatedAt()));
+            pstmt.setLong(4, course.getId());
+
+            pstmt.executeUpdate();
+
+        } catch (SQLException e) {
+            throw new RuntimeException("강좌 업데이트 중 오류가 발생했습니다.", e);
+        }
+    }
 }

--- a/src/main/java/com/lxp/course/service/CourseService.java
+++ b/src/main/java/com/lxp/course/service/CourseService.java
@@ -40,7 +40,7 @@ public class CourseService {
     public Course createCourse(Long instructorId, String title, String description,
             CourseLevel level) {
         User instructor = userRepository.findById(instructorId).orElseThrow(
-                () -> new IllegalArgumentException("존재하지 않는 사용자입니다. id=" + instructorId));
+                () -> new IllegalArgumentException("존재하지 않는 사용자입니다. userId=" + instructorId));
 
         Course course = Course.create(title, description, instructor, level);
 
@@ -91,6 +91,18 @@ public class CourseService {
 
     public Course getCourseWithDetail(Long courseId) {
         return courseRepository.findWithSectionsAndContentsById(courseId).orElseThrow(
-                () -> new IllegalArgumentException("존재하지 않는 강좌입니다. id=" + courseId));
+                () -> new IllegalArgumentException("존재하지 않는 강좌입니다. courseId=" + courseId));
+    }
+
+    public Course publishCourse(Long courseId) {
+        Course course = courseRepository.findWithSectionsAndContentsById(courseId)
+                .orElseThrow(
+                        () -> new IllegalArgumentException("존재하지 않는 강좌입니다. courseId=" + courseId));
+
+        course.publish();
+
+        courseRepository.update(course);
+
+        return course;
     }
 }


### PR DESCRIPTION
### 📝 구현 내용
강좌 발행 기능을 구현했습니다.
강좌 발행 기능은 발행 가능 조건을 만족한 강좌(Course)의 상태를 `PUBLISHED`로 변환하는 기능입니다.

### 📂 주요 변경 파일
- CourseRepository.java
- CourseService.java
- CourseController.java

## 🤔 고민했던 부분

어려움: Course의 update를 레포지토리 인터페이스로 강제할지, 서비스 계층에서 로직으로 해결할지를 고민했습니다.

선택: Repository 인터페이스에 `update()`를 명시적으로 분리하는 방식을 선택했습니다. `save()`에 INSERT/UPDATE를 모두 맡기는 방식도 고려했지만, `save()` 내부에서 id 유무로 분기할 경우 `publish()`와 `archive()`처럼 변경 컬럼이 다른 케이스를 처리하기 위해 결국 전체 컬럼을 덮어쓰거나 목적별로 재분기해야 하는 문제가 있었습니다.

결과: `save()`는 INSERT, `update()`는 UPDATE로 역할을 명확히 분리하여 의도를 드러낼 수 있었습니다. 또한 프레임워크 없이 JDBC를 직접 사용하는 구조에서 저장 시점을 명시적으로 드러내는 것이 코드 흐름 추적에 유리하다고 판단했고, `update()` 하나로 `publish()`와 `archive()` 두 케이스를 모두 처리할 수 있어 재사용성도 높일 수 있었습니다.

### 📌 참고사항
테스트한 정상/예외 케이스는 다음과 같습니다.

**TC-01: 정상 발행**
```
입력:
  강좌 ID: 2

기대 출력:
  강좌가 발행되었습니다. [ID: 2] 실전 스프링 부트 가이드
```

**TC-02: 이미 PUBLISHED 강좌 발행 시도**
```
입력:
  강좌 ID: 1

기대 출력:
  [오류] DRAFT 상태인 강좌만 발행할 수 있습니다.
```

**TC-03: 섹션 없는 DRAFT 강좌 발행 시도**
```
사전 조건: 섹션 없는 DRAFT 강좌 생성
  강좌 등록 메뉴에서 새 강좌 등록 (id=4로 생성된다고 가정)

입력:
  강좌 ID: 4

기대 출력:
  [오류] 강좌에 섹션이 최소 1개 이상 존재해야 합니다.
```

**TC-04: NORMAL 콘텐츠 없는 섹션이 있는 강좌 발행 시도**
```
사전 조건:
  1. 새 DRAFT 강좌 등록 (id=4로 생성된다고 가정)
  2. 섹션 등록 (id=4 강좌에 섹션 추가)
  3. 해당 섹션에 HIDDEN 콘텐츠만 추가

입력:
  강좌 ID: 4

기대 출력:
  [오류] 섹션 '섹션명'에 NORMAL 상태의 콘텐츠가 최소 1개 이상 존재해야 합니다.
```

**TC-05: 존재하지 않는 강좌 ID**
```
입력:
  강좌 ID: 999

기대 출력:
  [오류] 존재하지 않는 강좌입니다. id=999
```

**TC-06: 강좌 ID에 숫자가 아닌 값**
```
입력:
  강좌 ID: abc

기대 출력:
  [오류] ID는 숫자로 입력해주세요.
```